### PR TITLE
Add newsletter eligibility checker and make all eligibility checkers conditional

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -44,6 +44,17 @@ final class Configuration implements ConfigurationInterface
                 ->integerNode('prune_older_than')
                     ->info('Prune notifications that are older than this number of minutes. Default: 30 days (30 * 24 * 60)')
                     ->defaultValue(43_200) // 30 days
+                ->end()
+                ->arrayNode('eligibility_checkers')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('unsubscribed_customer')
+                            ->info('If this is true, you will not send notifications to customer who actively unsubscribed from a previous abandoned cart notification')
+                            ->defaultTrue()
+                        ->end()
+                        ->booleanNode('subscribed_to_newsletter')
+                            ->info('If this is true, you will not send notifications to customer who have not subscribed to your newsletter')
+                            ->defaultFalse()
         ;
 
         $this->addResourcesSection($rootNode);

--- a/src/DependencyInjection/SetonoSyliusAbandonedCartExtension.php
+++ b/src/DependencyInjection/SetonoSyliusAbandonedCartExtension.php
@@ -18,7 +18,7 @@ final class SetonoSyliusAbandonedCartExtension extends AbstractResourceExtension
         /**
          * @psalm-suppress PossiblyNullArgument
          *
-         * @var array{driver: string, salt: string, idle_threshold: int, prune_older_than: int, resources: array} $config
+         * @var array{driver: string, salt: string, idle_threshold: int, prune_older_than: int, eligibility_checkers: array{unsubscribed_customer: bool, subscribed_to_newsletter: bool}, resources: array} $config
          */
         $config = $this->processConfiguration($this->getConfiguration([], $container), $configs);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
@@ -30,6 +30,15 @@ final class SetonoSyliusAbandonedCartExtension extends AbstractResourceExtension
         $this->registerResources('setono_sylius_abandoned_cart', $config['driver'], $config['resources'], $container);
 
         $loader->load('services.xml');
+
+        $eligibilityCheckers = $config['eligibility_checkers'];
+        if ($eligibilityCheckers['unsubscribed_customer']) {
+            $loader->load('services/conditional/unsubscribed_customer.xml');
+        }
+
+        if ($eligibilityCheckers['subscribed_to_newsletter']) {
+            $loader->load('services/conditional/subscribed_to_newsletter.xml');
+        }
     }
 
     public function prepend(ContainerBuilder $container): void

--- a/src/EligibilityChecker/SubscribedToNewsletterNotificationEligibilityChecker.php
+++ b/src/EligibilityChecker/SubscribedToNewsletterNotificationEligibilityChecker.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\SyliusAbandonedCartPlugin\EligibilityChecker;
+
+use Setono\SyliusAbandonedCartPlugin\Model\NotificationInterface;
+use Webmozart\Assert\Assert;
+
+final class SubscribedToNewsletterNotificationEligibilityChecker implements NotificationEligibilityCheckerInterface
+{
+    public function check(NotificationInterface $notification): EligibilityCheck
+    {
+        $cart = $notification->getCart();
+        Assert::notNull($cart);
+
+        $customer = $cart->getCustomer();
+        if (null === $customer) {
+            // it is not the responsibility of this class to check this
+            return new EligibilityCheck(true);
+        }
+
+        return $customer->isSubscribedToNewsletter() ? new EligibilityCheck(true) : new EligibilityCheck(false, ['The customer is not subscribed to your newsletter']);
+    }
+}

--- a/src/Resources/config/services/conditional/subscribed_to_newsletter.xml
+++ b/src/Resources/config/services/conditional/subscribed_to_newsletter.xml
@@ -4,8 +4,9 @@
            xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="setono_sylius_abandoned_cart.notification_eligibility_checker.composite"
-                 class="Setono\SyliusAbandonedCartPlugin\EligibilityChecker\CompositeNotificationEligibilityChecker">
+        <service id="setono_sylius_abandoned_cart.notification_eligibility_checker.subscribed_to_newsletter"
+                 class="Setono\SyliusAbandonedCartPlugin\EligibilityChecker\SubscribedToNewsletterNotificationEligibilityChecker">
+            <tag name="setono_sylius_abandoned_cart.notification_eligibility_checker"/>
         </service>
     </services>
 </container>

--- a/src/Resources/config/services/conditional/unsubscribed_customer.xml
+++ b/src/Resources/config/services/conditional/unsubscribed_customer.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="setono_sylius_abandoned_cart.notification_eligibility_checker.unsubscribed_customer"
+                 class="Setono\SyliusAbandonedCartPlugin\EligibilityChecker\UnsubscribedCustomerNotificationEligibilityChecker">
+            <argument type="service" id="setono_sylius_abandoned_cart.repository.unsubscribed_customer"/>
+
+            <tag name="setono_sylius_abandoned_cart.notification_eligibility_checker"/>
+        </service>
+    </services>
+</container>

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -39,6 +39,10 @@ final class ConfigurationTest extends TestCase
             'salt' => 's3cr3t',
             'idle_threshold' => 60,
             'prune_older_than' => 43_200,
+            'eligibility_checkers' => [
+                'unsubscribed_customer' => true,
+                'subscribed_to_newsletter' => false,
+            ],
             'resources' => [
                 'notification' => [
                     'classes' => [

--- a/tests/DependencyInjection/SetonoSyliusAbandonedCartExtensionTest.php
+++ b/tests/DependencyInjection/SetonoSyliusAbandonedCartExtensionTest.php
@@ -28,5 +28,38 @@ final class SetonoSyliusAbandonedCartExtensionTest extends AbstractExtensionTest
 
         $this->assertContainerBuilderHasParameter('setono_sylius_abandoned_cart.salt', 's3cr3t');
         $this->assertContainerBuilderHasParameter('setono_sylius_abandoned_cart.idle_threshold', 60);
+        $this->assertContainerBuilderHasParameter('setono_sylius_abandoned_cart.prune_older_than', 43_200);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_load_eligibility_checkers(): void
+    {
+        $this->load([
+            'eligibility_checkers' => [
+                'unsubscribed_customer' => false,
+                'subscribed_to_newsletter' => false,
+            ],
+        ]);
+
+        $this->assertContainerBuilderNotHasService('setono_sylius_abandoned_cart.notification_eligibility_checker.unsubscribed_customer');
+        $this->assertContainerBuilderNotHasService('setono_sylius_abandoned_cart.notification_eligibility_checker.subscribed_to_newsletter');
+    }
+
+    /**
+     * @test
+     */
+    public function it_loads_eligibility_checkers(): void
+    {
+        $this->load([
+            'eligibility_checkers' => [
+                'unsubscribed_customer' => true,
+                'subscribed_to_newsletter' => true,
+            ],
+        ]);
+
+        $this->assertContainerBuilderHasService('setono_sylius_abandoned_cart.notification_eligibility_checker.unsubscribed_customer');
+        $this->assertContainerBuilderHasService('setono_sylius_abandoned_cart.notification_eligibility_checker.subscribed_to_newsletter');
     }
 }

--- a/tests/EligibilityChecker/SubscribedToNewsletterNotificationEligibilityCheckerTest.php
+++ b/tests/EligibilityChecker/SubscribedToNewsletterNotificationEligibilityCheckerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Setono\SyliusAbandonedCartPlugin\EligibilityChecker;
+
+use PHPUnit\Framework\TestCase;
+use Setono\SyliusAbandonedCartPlugin\EligibilityChecker\SubscribedToNewsletterNotificationEligibilityChecker;
+use Setono\SyliusAbandonedCartPlugin\Model\Notification;
+use Sylius\Component\Core\Model\Customer;
+use Sylius\Component\Core\Model\Order;
+
+/**
+ * @covers \Setono\SyliusAbandonedCartPlugin\EligibilityChecker\SubscribedToNewsletterNotificationEligibilityChecker
+ */
+final class SubscribedToNewsletterNotificationEligibilityCheckerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_eligible_when_customer_is_null(): void
+    {
+        $order = new Order();
+        $notification = new Notification();
+        $notification->setCart($order);
+
+        $checker = new SubscribedToNewsletterNotificationEligibilityChecker();
+        self::assertTrue($checker->check($notification)->eligible);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_eligible_when_customer_is_subscribed(): void
+    {
+        $customer = new Customer();
+        $customer->setSubscribedToNewsletter(true);
+
+        $order = new Order();
+        $order->setCustomer($customer);
+
+        $notification = new Notification();
+        $notification->setCart($order);
+
+        $checker = new SubscribedToNewsletterNotificationEligibilityChecker();
+        self::assertTrue($checker->check($notification)->eligible);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_non_eligible_when_customer_is_not_subscribed(): void
+    {
+        $customer = new Customer();
+        $customer->setSubscribedToNewsletter(false);
+
+        $order = new Order();
+        $order->setCustomer($customer);
+
+        $notification = new Notification();
+        $notification->setCart($order);
+
+        $checker = new SubscribedToNewsletterNotificationEligibilityChecker();
+        self::assertFalse($checker->check($notification)->eligible);
+    }
+}


### PR DESCRIPTION
Adds some more flex to the plugin and at the same time it adds an eligibility checker that will check if a customer is subscribed to the newsletter