### PR TITLE
Make URL generation independent of request context

### DIFF
--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -23,6 +23,7 @@
         "Sylius\\Component\\Mailer\\Sender\\SenderInterface",
         "Sylius\\Component\\Order\\Context\\CartContextInterface",
         "Sylius\\Component\\Order\\Context\\CartNotFoundException",
-        "Sylius\\Component\\Order\\Model\\OrderInterface"
+        "Sylius\\Component\\Order\\Model\\OrderInterface",
+        "Sylius\\Component\\Channel\\Model\\ChannelInterface"
     ]
 }

--- a/src/Mailer/EmailManager.php
+++ b/src/Mailer/EmailManager.php
@@ -34,6 +34,7 @@ final class EmailManager implements EmailManagerInterface
         Assert::notNull($order);
 
         $channel = $order->getChannel();
+        Assert::notNull($channel);
 
         $email = $notification->getEmail();
         Assert::notNull($email);
@@ -44,7 +45,7 @@ final class EmailManager implements EmailManagerInterface
             'localeCode' => $order->getLocaleCode(),
             'urls' => [
                 'cartRecovery' => $this->cartRecoveryUrlGenerator->generate($order),
-                'unsubscribe' => $this->unsubscribeUrlGenerator->generate($email, (string) $order->getLocaleCode()),
+                'unsubscribe' => $this->unsubscribeUrlGenerator->generate($channel, $email, (string) $order->getLocaleCode()),
             ],
         ]);
     }

--- a/src/UrlGenerator/CartRecoveryUrlGenerator.php
+++ b/src/UrlGenerator/CartRecoveryUrlGenerator.php
@@ -6,6 +6,7 @@ namespace Setono\SyliusAbandonedCartPlugin\UrlGenerator;
 
 use Sylius\Component\Core\Model\OrderInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Webmozart\Assert\Assert;
 
 final class CartRecoveryUrlGenerator implements CartRecoveryUrlGeneratorInterface
 {
@@ -21,9 +22,11 @@ final class CartRecoveryUrlGenerator implements CartRecoveryUrlGeneratorInterfac
 
     public function generate(
         OrderInterface $order,
-        array $parameters = [],
-        int $referenceType = UrlGeneratorInterface::ABSOLUTE_URL
+        array $parameters = []
     ): string {
+        $channel = $order->getChannel();
+        Assert::notNull($channel);
+
         $parameters = array_merge([
             'tokenValue' => $order->getTokenValue(),
             'utm_source' => 'sylius',
@@ -32,6 +35,11 @@ final class CartRecoveryUrlGenerator implements CartRecoveryUrlGeneratorInterfac
             '_locale' => $order->getLocaleCode(),
         ], $parameters);
 
-        return $this->urlGenerator->generate($this->route, $parameters, $referenceType);
+        return sprintf(
+            '%s://%s%s',
+            $this->urlGenerator->getContext()->getScheme(),
+            (string) $channel->getHostname(),
+            $this->urlGenerator->generate($this->route, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH)
+        );
     }
 }

--- a/src/UrlGenerator/CartRecoveryUrlGeneratorInterface.php
+++ b/src/UrlGenerator/CartRecoveryUrlGeneratorInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Setono\SyliusAbandonedCartPlugin\UrlGenerator;
 
 use Sylius\Component\Core\Model\OrderInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 interface CartRecoveryUrlGeneratorInterface
 {
@@ -14,7 +13,6 @@ interface CartRecoveryUrlGeneratorInterface
      */
     public function generate(
         OrderInterface $order,
-        array $parameters = [],
-        int $referenceType = UrlGeneratorInterface::ABSOLUTE_URL
+        array $parameters = []
     ): string;
 }

--- a/src/UrlGenerator/UnsubscribeUrlGenerator.php
+++ b/src/UrlGenerator/UnsubscribeUrlGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Setono\SyliusAbandonedCartPlugin\UrlGenerator;
 
 use Setono\SyliusAbandonedCartPlugin\Hasher\EmailHasherInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final class UnsubscribeUrlGenerator implements UnsubscribeUrlGeneratorInterface
@@ -23,10 +24,10 @@ final class UnsubscribeUrlGenerator implements UnsubscribeUrlGeneratorInterface
     }
 
     public function generate(
+        ChannelInterface $channel,
         string $email,
         string $locale,
-        array $parameters = [],
-        int $referenceType = UrlGeneratorInterface::ABSOLUTE_URL
+        array $parameters = []
     ): string {
         $parameters = array_merge([
             'email' => $email,
@@ -37,6 +38,11 @@ final class UnsubscribeUrlGenerator implements UnsubscribeUrlGeneratorInterface
             '_locale' => $locale,
         ], $parameters);
 
-        return $this->urlGenerator->generate($this->route, $parameters, $referenceType);
+        return sprintf(
+            '%s://%s%s',
+            $this->urlGenerator->getContext()->getScheme(),
+            (string) $channel->getHostname(),
+            $this->urlGenerator->generate($this->route, $parameters, UrlGeneratorInterface::ABSOLUTE_PATH)
+        );
     }
 }

--- a/src/UrlGenerator/UnsubscribeUrlGeneratorInterface.php
+++ b/src/UrlGenerator/UnsubscribeUrlGeneratorInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Setono\SyliusAbandonedCartPlugin\UrlGenerator;
 
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 
 interface UnsubscribeUrlGeneratorInterface
 {
@@ -12,9 +12,9 @@ interface UnsubscribeUrlGeneratorInterface
      * Generates an unsubscribe URL for a given email
      */
     public function generate(
+        ChannelInterface $channel,
         string $email,
         string $locale,
-        array $parameters = [],
-        int $referenceType = UrlGeneratorInterface::ABSOLUTE_URL
+        array $parameters = []
     ): string;
 }

--- a/tests/UrlGenerator/CartRecoveryUrlGeneratorTest.php
+++ b/tests/UrlGenerator/CartRecoveryUrlGeneratorTest.php
@@ -6,6 +6,7 @@ namespace Tests\Setono\SyliusAbandonedCartPlugin\UrlGenerator;
 
 use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusAbandonedCartPlugin\UrlGenerator\CartRecoveryUrlGenerator;
+use Sylius\Component\Core\Model\Channel;
 use Sylius\Component\Core\Model\Order;
 use Symfony\Component\Routing\Route;
 
@@ -26,9 +27,13 @@ final class CartRecoveryUrlGeneratorTest extends UrlGeneratorAwareTestCase
      */
     public function it_generates_url(): void
     {
+        $channel = new Channel();
+        $channel->setHostname('example.com');
+
         $order = new Order();
         $order->setLocaleCode('en_US');
         $order->setTokenValue('token');
+        $order->setChannel($channel);
 
         $cartRecoveryUrlGenerator = new CartRecoveryUrlGenerator($this->urlGenerator, 'sylius_shop_cart_summary');
         self::assertSame('https://example.com/cart?tokenValue=token&utm_source=sylius&utm_medium=email&utm_campaign=Abandoned%20Cart&_locale=en_US', $cartRecoveryUrlGenerator->generate($order));
@@ -39,9 +44,13 @@ final class CartRecoveryUrlGeneratorTest extends UrlGeneratorAwareTestCase
      */
     public function it_allows_to_overwrite_parameters(): void
     {
+        $channel = new Channel();
+        $channel->setHostname('example.com');
+
         $order = new Order();
         $order->setLocaleCode('en_US');
         $order->setTokenValue('token');
+        $order->setChannel($channel);
 
         $cartRecoveryUrlGenerator = new CartRecoveryUrlGenerator($this->urlGenerator, 'sylius_shop_cart_summary');
         self::assertSame('https://example.com/cart?tokenValue=token&utm_source=sylius&utm_medium=email&utm_campaign=Abandoned%20Cart%20%232&_locale=en_US&utm_content=Number%20two', $cartRecoveryUrlGenerator->generate($order, [

--- a/tests/UrlGenerator/UnsubscribeUrlGeneratorTest.php
+++ b/tests/UrlGenerator/UnsubscribeUrlGeneratorTest.php
@@ -7,6 +7,7 @@ namespace Tests\Setono\SyliusAbandonedCartPlugin\UrlGenerator;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Setono\SyliusAbandonedCartPlugin\Hasher\EmailHasher;
 use Setono\SyliusAbandonedCartPlugin\UrlGenerator\UnsubscribeUrlGenerator;
+use Sylius\Component\Core\Model\Channel;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -32,9 +33,12 @@ final class UnsubscribeUrlGeneratorTest extends UrlGeneratorAwareTestCase
             'setono_sylius_abandoned_cart_shop_unsubscribe_customer'
         );
 
+        $channel = new Channel();
+        $channel->setHostname('example.com');
+
         self::assertSame(
             'https://example.com/abandoned-cart/unsubscribe?email=johndoe@example.com&hash=2ac21379842b5445001475a596caab5843ecbc6be46c27f882cb6c0bd75fb9f9&utm_source=sylius&utm_medium=email&utm_campaign=Abandoned%20Cart%20Unsubscribe&_locale=en_US',
-            $urlGenerator->generate('johndoe@example.com', 'en_US')
+            $urlGenerator->generate($channel, 'johndoe@example.com', 'en_US')
         );
     }
 
@@ -49,9 +53,12 @@ final class UnsubscribeUrlGeneratorTest extends UrlGeneratorAwareTestCase
             'setono_sylius_abandoned_cart_shop_unsubscribe_customer'
         );
 
+        $channel = new Channel();
+        $channel->setHostname('example.com');
+
         self::assertSame(
             'https://example.com/abandoned-cart/unsubscribe?email=johndoe@example.com&hash=2ac21379842b5445001475a596caab5843ecbc6be46c27f882cb6c0bd75fb9f9&utm_source=sylius&utm_medium=email&utm_campaign=Abandoned%20Cart%20Unsubscribe%20%232&_locale=en_US&utm_content=Number%20two',
-            $urlGenerator->generate('johndoe@example.com', 'en_US', [
+            $urlGenerator->generate($channel, 'johndoe@example.com', 'en_US', [
                 'utm_campaign' => 'Abandoned Cart Unsubscribe #2',
                 'utm_content' => 'Number two',
             ])


### PR DESCRIPTION
This PR will make the URL generation independent of the request context. We will use the channel to retrieve the hostname instead of the request context.