### PR TITLE
Fix email template to respect customer locale

### DIFF
--- a/src/Resources/translations/messages.da.yml
+++ b/src/Resources/translations/messages.da.yml
@@ -9,6 +9,8 @@ setono_sylius_abandoned_cart:
             continue_shopping: Fortsæt dit indkøb
             unsubscribe: Afmeld
             cart_contents: Du havde følgende exceptionelle og velvalgte varer i kurven, da der var noget, der afbrød dit indkøb. Lad være med at forlad disse varer!
+            quantity: Antal
+            product: Produkt
     form:
         unsubscribed_customer:
             email: Email

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -9,6 +9,8 @@ setono_sylius_abandoned_cart:
             continue_shopping: Continue shopping
             unsubscribe: Unsubscribe
             cart_contents: You had the following exceptional, well selected items in your cart when something interrupted your shopping. Don't abandon this!
+            quantity: Quantity
+            product: Product
     form:
         unsubscribed_customer:
             email: Email

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -9,6 +9,8 @@ setono_sylius_abandoned_cart:
             continue_shopping: Continuer mes achats
             unsubscribe: Me désinscrire
             cart_contents: Votre sélection d'article exceptionnel vous attends. N'abandonnez pas si vite !
+            quantity: Quantité
+            product: Produit
     form:
         unsubscribed_customer:
             email: Email

--- a/src/Resources/views/email/notification.html.twig
+++ b/src/Resources/views/email/notification.html.twig
@@ -5,7 +5,7 @@
 
 {% block content %}
     <div style="text-align: center; margin-bottom: 30px;">
-        {{ 'setono_sylius_abandoned_cart.emails.notification.intro'|trans({ '%customer%': notification.recipientFirstName })|raw }}
+        {{ 'setono_sylius_abandoned_cart.emails.notification.intro'|trans({ '%customer%': notification.recipientFirstName }, null, localeCode)|raw }}
     </div>
 
     <div style="text-align: center; margin-bottom: 30px;">
@@ -15,13 +15,13 @@
     </div>
 
     <div style="text-align: center; margin-bottom: 30px;">
-        {{ 'setono_sylius_abandoned_cart.emails.notification.cart_contents'|trans({ '%customer%': notification.recipientFirstName })|raw }}
+        {{ 'setono_sylius_abandoned_cart.emails.notification.cart_contents'|trans({ '%customer%': notification.recipientFirstName }, null, localeCode)|raw }}
     </div>
 
     <table cellpadding="0" cellspacing="0" border="0" width="100%" style=" margin-bottom: 30px;">
         <tr>
-            <th style="text-align: left; padding: 5px 10px">Quantity</th>
-            <th style="text-align: left; padding: 5px 10px">Product</th>
+            <th style="text-align: left; padding: 5px 10px">{{ 'setono_sylius_abandoned_cart.emails.notification.quantity'|trans({}, null, localeCode) }}</th>
+            <th style="text-align: left; padding: 5px 10px">{{ 'setono_sylius_abandoned_cart.emails.notification.product'|trans({}, null, localeCode) }}</th>
         </tr>
         {# @var \Sylius\Component\Core\Model\OrderItemInterface item #}
         {% for item in notification.cart.items %}


### PR DESCRIPTION
## Summary
- Add missing `localeCode` parameter to `intro` and `cart_contents` translation calls in the notification email template, matching how `continue_shopping` and `unsubscribe` already pass it
- Replace hardcoded English "Quantity" and "Product" table headers with translatable keys
- Add `quantity` and `product` translation keys to all three language files (en, da, fr)

## Test plan
- [ ] Send an abandoned cart email to a customer with a non-English locale and verify all text (intro, cart contents, table headers, buttons) renders in the correct language
- [ ] Verify English locale emails still render correctly